### PR TITLE
feat: add proxy support to tid HTTP client

### DIFF
--- a/src/apiutils.nim
+++ b/src/apiutils.nim
@@ -197,7 +197,10 @@ proc fetchRaw*(req: ApiReq): Future[string] {.async.} =
     var session = await getAndValidateSession(req)
     let url = req.toUrl(session.kind)
 
+    echo "fetchRaw url: ", url
+
     fetchImpl result:
+      echo "fetchRaw result: ", result
       if not (result.startsWith('{') or result.startsWith('[')):
         echo resp.status, ": ", result, " --- url: ", url
         result.setLen(0)

--- a/src/http_pool.nim
+++ b/src/http_pool.nim
@@ -18,6 +18,9 @@ proc setHttpProxy*(url: string; auth: string) =
   else:
     proxy = nil
 
+proc getHttpProxy*(): Proxy =
+  return proxy
+
 proc release*(pool: HttpPool; client: AsyncHttpClient; badClient=false) =
   if pool.conns.len >= maxConns or badClient:
     try: client.close()

--- a/src/redis_cache.nim
+++ b/src/redis_cache.nim
@@ -142,7 +142,10 @@ proc getCachedUsername*(userId: string): Future[string] {.async.} =
   if username != redisNil:
     result = username
   else:
+    echo "getGraphUserById: ", userId
     let user = await getGraphUserById(userId)
+    echo "user: ", user
+
     result = user.username
     await setEx(key, baseCacheTime, result)
     if result.len > 0 and user.id.len > 0:

--- a/src/tid.nim
+++ b/src/tid.nim
@@ -1,6 +1,7 @@
 import std/[asyncdispatch, base64, httpclient, random, strutils, sequtils, times]
 import nimcrypto
 import experimental/parser/tid
+import http_pool
 
 randomize()
 
@@ -18,7 +19,7 @@ proc getPair(): Future[TidPair] {.async.} =
   if cachedPairs.len == 0 or int(epochTime()) - lastCached > ttlSec:
     lastCached = int(epochTime())
 
-    let client = newAsyncHttpClient()
+    let client = newAsyncHttpClient(proxy=getHttpProxy())
     defer: client.close()
 
     let resp = await client.get(pairsUrl)


### PR DESCRIPTION
## Description

This PR adds proxy support to the tid HTTP client by exposing the proxy configuration and using it when creating HTTP clients.

## Changes

- **Added `getHttpProxy()` function** in `http_pool.nim` to expose the proxy configuration
- **Updated `tid.nim`** to use the proxy when creating `AsyncHttpClient` instances
- **Added debug logging** in `apiutils.nim` and `redis_cache.nim` for troubleshooting purposes

## Motivation

The tid HTTP client was not respecting the proxy configuration set via `setHttpProxy()`, which could cause issues in environments where proxy usage is required.

## Testing

- [ ] Verified that proxy is used when creating HTTP client in tid.nim
- [ ] Tested with proxy configuration enabled
- [ ] Verified debug logging works as expected

## Related Issues

<!-- Link any related issues here -->