### PR TITLE
feat(api): add error_type field and HTTP status codes for errors

### DIFF
--- a/src/jsons/status.nim
+++ b/src/jsons/status.nim
@@ -60,7 +60,7 @@ proc createJsonApiStatusRouter*(cfg: Config) =
         var error = "Tweet not found"
         if conv != nil and conv.tweet != nil and conv.tweet.tombstone.len > 0:
           error = conv.tweet.tombstone
-        respJsonError error
+        respJsonError(error, "not_found", Http404)
 
       respJsonSuccess formatConversationAsJson(conv)
 

--- a/src/jsons/timeline.nim
+++ b/src/jsons/timeline.nim
@@ -121,7 +121,7 @@ proc createJsonApiTimelineRouter*(cfg: Config) =
       if username.len > 0:
         respJsonSuccess formatUserName(username)
       else:
-        respJsonError "User not found"
+        respJsonError("User not found", "not_found", Http404)
 
     get "/api/@name/profile":
       cond @"name" notin ["pic", "gif", "video", "search", "settings", "login",
@@ -135,7 +135,7 @@ proc createJsonApiTimelineRouter*(cfg: Config) =
         query.fromUser = names
 
       var profile = await fetchProfile("", query, skipRail = false)
-      if profile.user.username.len == 0: respJsonError "User not found"
+      if profile.user.username.len == 0: respJsonError("User not found", "not_found", Http404)
 
       respJsonSuccess formatProfileAsJson(profile)
 
@@ -160,6 +160,6 @@ proc createJsonApiTimelineRouter*(cfg: Config) =
         respJsonSuccess formatTimelineAsJson(timeline)
       else:
         var profile = await fetchProfile(after, query, skipRail = true)
-        if profile.tweets.content.len == 0: respJsonError "User not found"
+        if profile.tweets.content.len == 0: respJsonError("User not found", "not_found", Http404)
         profile.tweets.beginning = true
         respJsonSuccess formatTimelineAsJson(profile.tweets)

--- a/src/routes/router_utils.nim
+++ b/src/routes/router_utils.nim
@@ -53,12 +53,14 @@ template respJsonSuccess*(data: JsonNode) =
   }
   resp $successResponse, "application/json"
 
-template respJsonError*(message: string) =
-  let errorResponse = %*{
+template respJsonError*(message: string, errorType: string = "", httpCode: HttpCode = Http200) =
+  var errorResponse = %*{
     "code": -1,
     "error": message
   }
-  resp $errorResponse, "application/json"
+  if errorType.len > 0:
+    errorResponse["error_type"] = %errorType
+  resp httpCode, $errorResponse, "application/json"
 
 template respJsonNull*() =
   let nullResponse = newJNull()


### PR DESCRIPTION
## Summary
- Add optional `error_type` parameter to `respJsonError` template for reliable client-side error detection
- Add `httpCode` parameter to return proper HTTP status codes
- Use HTTP 404 for `not_found` errors (tweet/user not found)

## Changes

### Before
```
HTTP/1.1 200 OK
{"code": -1, "error": "Tweet not found"}
```

### After
```
HTTP/1.1 404 Not Found
{"code": -1, "error": "Tweet not found", "error_type": "not_found"}
```

## Benefits
Clients can now detect not-found errors by:
1. HTTP status code (`response.status === 404`)
2. JSON field (`response.error_type === 'not_found'`)

This is more reliable than parsing error message strings.

## Related
- https://github.com/DimensionDev/firefly-social/pull/7784