### PR TITLE
feat(api): extend structured error handling to all error responses

### DIFF
--- a/src/jsons/search.nim
+++ b/src/jsons/search.nim
@@ -14,7 +14,7 @@ proc createJsonApiSearchRouter*(cfg: Config) =
     get "/api/search?":
       let q = @"q"
       if q.len > 500:
-        respJsonError "Search input too long."
+        respJsonError("Search input too long.", "invalid_input", Http400)
 
       let
         prefs = cookiePrefs()
@@ -23,7 +23,7 @@ proc createJsonApiSearchRouter*(cfg: Config) =
       case query.kind
       of users:
         if "," in q:
-          respJsonError "Invalid search input"
+          respJsonError("Invalid search input", "invalid_input", Http400)
         var users: Result[User]
         try:
           users = await getGraphUserSearch(query, getCursor())
@@ -32,10 +32,10 @@ proc createJsonApiSearchRouter*(cfg: Config) =
         respJsonSuccess formatUsersAsJson(users)
       of tweets:
         let timeline = await getGraphTweetSearch(query, getCursor())
-        if timeline.content.len == 0: respJsonError "No results found"
+        if timeline.content.len == 0: respJsonError("No results found", "no_results", Http200)
         respJsonSuccess formatTimelineAsJson(timeline)
       else:
-        respJsonError "Invalid search"
+        respJsonError("Invalid search", "invalid_input", Http400)
 
     get "/api/hashtag/@hash":
       redirect("/search?q=" & encodeUrl("#" & @"hash"))

--- a/src/jsons/status.nim
+++ b/src/jsons/status.nim
@@ -52,7 +52,7 @@ proc createJsonApiStatusRouter*(cfg: Config) =
       let id = @"id"
 
       if id.len > 19 or id.any(c => not c.isDigit):
-        respJsonError "Invalid tweet ID"
+        respJsonError("Invalid tweet ID", "invalid_input", Http400)
 
       let conv = await getTweet(id, getCursor())
 

--- a/src/jsons/timeline.nim
+++ b/src/jsons/timeline.nim
@@ -155,7 +155,7 @@ proc createJsonApiTimelineRouter*(cfg: Config) =
 
       if query.fromUser.len != 1:
         var timeline = await getGraphTweetSearch(query, after)
-        if timeline.content.len == 0: respJsonError "No results found"
+        if timeline.content.len == 0: respJsonError("No results found", "no_results", Http200)
         timeline.beginning = true
         respJsonSuccess formatTimelineAsJson(timeline)
       else:

--- a/src/routes/router_utils.nim
+++ b/src/routes/router_utils.nim
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 import strutils, sequtils, uri, tables, json
-from jester import Request, cookies
+from jester import Request, cookies, HttpCode, Http200
 
 import ../views/general
 import ".."/[utils, prefs, types]


### PR DESCRIPTION
## Summary

This PR extends the structured error handling introduced in #19 to cover all remaining API error cases.

## Changes

| File | Error Message | `error_type` | HTTP Code |
|------|---------------|--------------|-----------|
| `status.nim` | "Invalid tweet ID" | `invalid_input` | 400 |
| `search.nim` | "Search input too long." | `invalid_input` | 400 |
| `search.nim` | "Invalid search input" | `invalid_input` | 400 |
| `search.nim` | "No results found" | `no_results` | 200 |
| `search.nim` | "Invalid search" | `invalid_input` | 400 |
| `timeline.nim` | "No results found" | `no_results` | 200 |

## Design Decisions

- **`invalid_input` + Http400**: Used for all client input validation errors
- **`no_results` + Http200**: Used for valid searches that return empty results (semantic success)

## Test plan

- [ ] Verify error responses include `error_type` field
- [ ] Verify HTTP status codes are correctly set
- [ ] Test backward compatibility with existing API clients
