### PR TITLE
fix: resolve HttpHeaderValues type mismatch in CORS origin header

### DIFF
--- a/src/nitter.nim
+++ b/src/nitter.nim
@@ -76,7 +76,7 @@ settings:
 
 routes:
   options re"/api/.*":
-    let origin = if request.headers.hasKey("Origin"): request.headers["Origin"] else: "*"
+    let origin = if request.headers.hasKey("Origin"): request.headers["Origin", 0] else: "*"
     resp Http204, {
       "Vary": "Origin",
       "Access-Control-Allow-Origin": origin,

--- a/src/routes/router_utils.nim
+++ b/src/routes/router_utils.nim
@@ -59,7 +59,7 @@ template applyUrlPrefs*() {.dirty.} =
       redirect(request.path)
 
 template corsOrigin*(): string {.dirty.} =
-  if request.headers.hasKey("Origin"): request.headers["Origin"] else: "*"
+  if request.headers.hasKey("Origin"): request.headers["Origin", 0] else: "*"
 
 template respJson*(node: JsonNode) =
   let origin = corsOrigin()


### PR DESCRIPTION
## Summary

- After merging upstream (`8db88bd`), jester's `headers["key"]` now returns `HttpHeaderValues = distinct seq[string]` instead of `string`
- The if-else expression `request.headers["Origin"] else: "*"` failed because the branches had incompatible types (`HttpHeaderValues` vs `string`)
- Fix uses the two-argument accessor `headers["Origin", 0]` to get the first value as a plain `string`, consistent with how `src/routes/media.nim` already accesses headers

## Files changed

- `src/routes/router_utils.nim:62` — `corsOrigin` template
- `src/nitter.nim:79` — OPTIONS preflight handler

## Test plan

- [ ] Docker image builds successfully via GitHub Actions
- [ ] CORS `Origin` header is reflected correctly in API responses
- [ ] Preflight OPTIONS requests to `/api/*` return the correct `Access-Control-Allow-Origin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)