### PR TITLE
feat(api): add JSON endpoint for Twitter account about information

### DIFF
--- a/src/jsons/timeline.nim
+++ b/src/jsons/timeline.nim
@@ -139,6 +139,28 @@ proc formatProfileAsJson*(profile: Profile): JsonNode =
         profile.pinned)) else: newJNull()
   }
 
+proc formatAccountInfoAsJson*(info: AccountInfo): JsonNode =
+  proc dateToUnix(dt: DateTime): int64 =
+    if dt.year > 0: dt.toTime.toUnix() else: 0
+
+  return %*{
+    "username": info.username,
+    "fullname": info.fullname,
+    "userPic": info.userPic,
+    "joinDate": dateToUnix(info.joinDate),
+    "verifiedType": $info.verifiedType,
+    "suspended": info.suspended,
+    "basedIn": info.basedIn,
+    "source": info.source,
+    "usernameChanges": info.usernameChanges,
+    "lastUsernameChange": dateToUnix(info.lastUsernameChange),
+    "affiliateUsername": info.affiliateUsername,
+    "affiliateLabel": info.affiliateLabel,
+    "isIdentityVerified": info.isIdentityVerified,
+    "verifiedSince": dateToUnix(info.verifiedSince),
+    "overrideVerifiedYear": info.overrideVerifiedYear
+  }
+
 proc createJsonApiTimelineRouter*(cfg: Config) =
   router jsonapi_timeline:
     get "/api/i/user/@user_id":
@@ -148,6 +170,17 @@ proc createJsonApiTimelineRouter*(cfg: Config) =
         respJsonSuccess formatUserName(username)
       else:
         respJsonError("User not found", "not_found", Http404)
+
+    get "/api/@name/about":
+      cond @"name".allCharsInSet({'a'..'z', 'A'..'Z', '0'..'9', '_'})
+      let
+        name = @"name"
+        info = await getCachedAccountInfo(name)
+      if info.suspended:
+        respJsonError("Account suspended", "suspended", Http200)
+      if info.username.len == 0:
+        respJsonError("User not found", "not_found", Http404)
+      respJsonSuccess formatAccountInfoAsJson(info)
 
     get "/api/@name/profile":
       cond @"name" notin ["pic", "gif", "video", "search", "settings", "login",


### PR DESCRIPTION
## Summary

- Adds `/api/:name/about` JSON endpoint that returns `AccountInfo` data from the nitter about page
- Returns join date, verified status (with date), location (basedIn), username changes, affiliate info, and connected source
- Follows the same `respJsonSuccess` / `respJsonError` pattern as existing JSON API endpoints
- All `DateTime` fields are serialized as Unix timestamps (seconds); zero values return `0`

## Response shape

```json
{
  "code": 0,
  "data": {
    "username": "SpaceX",
    "fullname": "SpaceX",
    "userPic": "...",
    "joinDate": 1212883200,
    "verifiedType": "Blue",
    "suspended": false,
    "basedIn": "United States",
    "source": "",
    "usernameChanges": 0,
    "lastUsernameChange": 0,
    "affiliateUsername": "",
    "affiliateLabel": "",
    "isIdentityVerified": false,
    "verifiedSince": 0,
    "overrideVerifiedYear": 0
  }
}
```

## Test plan

- [ ] `GET /api/SpaceX/about` returns `200` with account info JSON
- [ ] `GET /api/nonexistentuser12345/about` returns `404` error JSON
- [ ] Suspended account returns suspended error JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)