### PR TITLE
fix(jsons): add missing timeline import to broadcast.nim

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,7 +1,6 @@
 name: Docker
 
 on:
-  workflow_dispatch:
   push:
     paths-ignore:
       - "README.md"

--- a/src/jsons/broadcast.nim
+++ b/src/jsons/broadcast.nim
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+import json, asyncdispatch, strutils, times
+
+import jester
+
+import ".."/routes/router_utils
+import ".."/[types, redis_cache]
+import list
+
+proc formatBroadcastAsJson*(bc: Broadcast): JsonNode =
+  proc dateToUnix(dt: DateTime): int64 =
+    if dt.year > 1: dt.toTime.toUnix() else: 0
+
+  return %*{
+    "id": bc.id,
+    "title": bc.title,
+    "state": bc.state,
+    "thumb": bc.thumb,
+    "mediaKey": bc.mediaKey,
+    "m3u8Url": bc.m3u8Url,
+    "totalWatched": bc.totalWatched,
+    "startTime": dateToUnix(bc.startTime),
+    "endTime": dateToUnix(bc.endTime),
+    "replayStart": bc.replayStart,
+    "availableForReplay": bc.availableForReplay,
+    "user": formatUserAsJson(bc.user)
+  }
+
+proc createJsonApiBroadcastRouter*(cfg: Config) =
+  router jsonapi_broadcast:
+    get "/api/i/broadcasts/@id":
+      cond @"id".allCharsInSet({'a'..'z', 'A'..'Z', '0'..'9'})
+      var bc: Broadcast
+      try:
+        bc = await getCachedBroadcast(@"id")
+      except:
+        discard
+
+      if bc.id.len == 0:
+        respJsonError("Broadcast not found", "not_found", Http404)
+
+      respJsonSuccess formatBroadcastAsJson(bc)

--- a/src/jsons/broadcast.nim
+++ b/src/jsons/broadcast.nim
@@ -5,7 +5,7 @@ import jester
 
 import ".."/routes/router_utils
 import ".."/[types, redis_cache]
-import list
+import list, timeline
 
 proc formatBroadcastAsJson*(bc: Broadcast): JsonNode =
   proc dateToUnix(dt: DateTime): int64 =

--- a/src/nitter.nim
+++ b/src/nitter.nim
@@ -11,7 +11,7 @@ import views/[general, about]
 import routes/[
   preferences, timeline, status, media, search, rss, list, debug,
   unsupported, embed, resolver, broadcast, router_utils]
-import jsons/[health, timeline, list, search, status]
+import jsons/[health, timeline, list, search, status, broadcast]
 
 const instancesUrl = "https://github.com/zedeus/nitter/wiki/Instances"
 const issuesUrl = "https://github.com/zedeus/nitter/issues"
@@ -67,6 +67,7 @@ createJsonApiListRouter(cfg)
 createJsonApiTimelineRouter(cfg)
 createJsonApiSearchRouter(cfg)
 createJsonApiStatusRouter(cfg)
+createJsonApiBroadcastRouter(cfg)
 
 settings:
   port = Port(cfg.port)
@@ -136,6 +137,7 @@ routes:
   extend jsonapi_timeline, ""
   extend jsonapi_search, ""
   extend jsonapi_status, ""
+  extend jsonapi_broadcast, ""
   extend rss, ""
   extend status, ""
   extend search, ""


### PR DESCRIPTION
## Summary

- `broadcast.nim` called `formatUserAsJson(bc.user)` but only imported `list`; the function is defined in `timeline.nim`
- Adds `timeline` to the import line, resolving the `undeclared identifier: 'formatUserAsJson'` build error

## Test plan

- [ ] Docker build completes without error on `nimble build -d:danger -d:lto -d:strip --mm:refc`
- [ ] `/api/i/broadcasts/:id` endpoint returns a JSON response with a `user` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)