### PR TITLE
fix(jsons): add missing timeline import to broadcast.nim

### DIFF
--- a/src/jsons/broadcast.nim
+++ b/src/jsons/broadcast.nim
@@ -5,7 +5,7 @@ import jester
 
 import ".."/routes/router_utils
 import ".."/[types, redis_cache]
-import list
+import list, timeline
 
 proc formatBroadcastAsJson*(bc: Broadcast): JsonNode =
   proc dateToUnix(dt: DateTime): int64 =


### PR DESCRIPTION
## Summary

- `broadcast.nim` called `formatUserAsJson(bc.user)` but only imported `list`; the function is defined in `timeline.nim`
- Adds `timeline` to the import line, resolving the `undeclared identifier: 'formatUserAsJson'` Docker build error

## Test plan

- [ ] Docker build completes without error on `nimble build -d:danger -d:lto -d:strip --mm:refc`
- [ ] `/api/i/broadcasts/:id` endpoint returns a JSON response with a `user` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)